### PR TITLE
Extend and modernize metainfo

### DIFF
--- a/data/io.github.sss_says_snek.diurnals.metainfo.xml.in
+++ b/data/io.github.sss_says_snek.diurnals.metainfo.xml.in
@@ -5,7 +5,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
   <name>Diurnals</name>
-  <summary>Receive a daily popup to notify about upcoming Todoist tasks</summary>
+  <summary>Get daily Todoist notifications</summary>
 
   <developer id="io.github.sss_says_snek">
     <name>Brandon C</name>
@@ -33,6 +33,11 @@
   </releases>
 
   <url type="homepage">https://github.com/SSS-Says-Snek/diurnals</url>
+  <url type="bugtracker">https://github.com/SSS-Says-Snek/diurnals/issues</url>
+  <url type="vcs-browser">https://github.com/SSS-Says-Snek/diurnals</url>
+  <url type="contact">https://s4aysnek.com/</url>
+  <url type="contribute">https://github.com/SSS-Says-Snek/diurnals</url>
+  <url type="translate">https://github.com/SSS-Says-Snek/diurnals/tree/main/po</url>
 
   <screenshots>
     <screenshot type="default">
@@ -44,4 +49,15 @@
       <caption>The tasks screen on dark mode</caption>
     </screenshot>
   </screenshots>
+
+  <requires>
+    <display_length compare="ge">360</display_length>
+    <internet>always</internet>
+  </requires>
+
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </supports>
 </component>


### PR DESCRIPTION
Improves the presentation of Diurnals in app stores:

- Shorten summary
- Add various `<url>` tags
- Add HW support information (supported screen sizes, input devices and internet access)
- Move `<releases>` to the bottom as it'll inevitably get pretty long after a while

Cheers!