### PR TITLE
Add Flathub badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 ## Installation
 
+[![Get it on Flathub](https://flathub.org/api/badge?svg&locale=en)](https://flathub.org/apps/io.github.sss_says_snek.diurnals)
+
 [![Packaging status](https://repology.org/badge/vertical-allrepos/diurnals.svg)](https://repology.org/project/diurnals/versions)
 
 ### Arch Linux (AUR)


### PR DESCRIPTION
Adds a clickable Flathub button to the README file.